### PR TITLE
Spread varargs in text-formatting extension methods

### DIFF
--- a/src/main/kotlin/dev/qixils/quasicolon/bot/Extensions.kt
+++ b/src/main/kotlin/dev/qixils/quasicolon/bot/Extensions.kt
@@ -12,7 +12,7 @@ val Interaction.context: Context
     get() = Context.fromInteraction(this)
 
 suspend fun Context.text(value: Key, vararg args: Any?): String =
-    Text.single(value, args).asString(this).awaitSingle()
+    Text.single(value, *args).asString(this).awaitSingle()
 
 suspend fun Context.text(value: String, vararg args: Any?): String =
-    text(botKey(value), args)
+    text(botKey(value), *args)


### PR DESCRIPTION
Fixes reminder formatting.

Before:
![image](https://github.com/user-attachments/assets/f02066d0-b063-4823-91d1-797c77bed44b)

After:
![image](https://github.com/user-attachments/assets/a03994ca-55d8-4931-b292-98865b0ee60b)
